### PR TITLE
DM-34274: Create reusable workflow for Sphinx technote CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'thursday'
+      time: '09:00'
+      timezone: America/Toronto

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,68 @@
+name: CI
+
+'on':
+  workflow_call:
+    inputs:
+      handle:
+        description: 'The document handle (lower-case subdomain).'
+        required: true
+        type: string
+      build_command:
+        description: 'Shell command(s) to build the technote.'
+        default: 'make html'
+        required: false
+        type: string
+      upload:
+        description: 'Flag to enable uploads'
+        default: true
+        required: false
+        type: boolean
+      apt_packages:
+        description: 'Space-delimited list of apt-get packages to install before build (e.g. graphviz)'
+        default: ''
+        required: false
+        type: string
+    secrets:
+      ltd_username:
+        description: 'LTD username'
+        required: true
+      ltd_password:
+        description: 'LTD password'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for metadata
+          submodules: true
+
+      - name: Install apt packages
+        if: ${{ inputs.apt_packages}}
+        run: sudo apt-get install -y ${{ inputs.apt_packages }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+
+      - name: Python install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install ltd-conveyor
+
+      - name: Build
+        run: |
+          ${{ inputs.build_command }}
+
+      - name: Upload
+        if: ${{ inputs.upload }}
+        env:
+          LTD_PASSWORD: ${{ secrets.ltd_password }}
+          LTD_USERNAME: ${{ secrets.ltd_username }}
+        run: |
+          ltd upload --gh --dir _build/html --product ${{ inputs.handle }}

--- a/.github/workflows/this-release.yaml
+++ b/.github/workflows/this-release.yaml
@@ -1,0 +1,13 @@
+name: Update Major Version Tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  update-majorver:
+    name: Update Major Version Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nowactions/update-majorver@v1

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 LSST SQuaRE
+Copyright (c) 2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ jobs:
 
 - `ltd_username` (required). The account username for the LTD service. Generally this is the org-wide GitHub Actions Secret, `ltd_username: ${{ secrets.LTD_USERNAME }}`. If `inputs.upload` is `false`, this can be left as an empty string.
 - `ltd_password` (required). The account password for the LTD service. Generally this is the org-wide GitHub Actions Secret, `ltd_username: ${{ secrets.LTD_PASSWORD }}`. If `inputs.upload` is `false`, this can be left as an empty string.
+
+## Developer guide
+
+This repository enables us to centrally maintain the GitHub Actions workflows for Sphinx/reStructuredText technotes through [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows).
+
+Create new releases using the GitHub Releases UI and assign a tag with a semantic version, including a `v` prefix. Choose the semantic version based on compatibility for users of this workflow. If existing technotes will no longer operate under a new version of this workflow, bump the major version to `v2`.
+
+When a release is made, a new major version tag (i.e. `v1`, `v2`) is also made or moved using [nowactions/update-majorver](https://github.com/marketplace/actions/update-major-version).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
 # rubin-sphinx-technote-workflows
 
-**Reusable GitHub Actions Workflow for building Sphinx-based Rubin technotes.**
+**Reusable GitHub Actions workflows for building Sphinx-based Rubin technotes.**
+
+## ci.yaml
+
+The [ci.yaml](.github/workflows/ci.yaml) workflow runs a Sphinx/reStructuredText technote build and uploads the HTML product to _LSST the Docs._ [This workflow is used by the reStructuredText Technote template.](https://github.com/lsst/templates/tree/main/project_templates/technote_rst)
+
+Usage example:
+
+```yaml
+name: CI
+
+'on': [push, pull_request]
+
+jobs:
+  call-workflow:
+    uses: lsst-sqre/rubin-sphinx-technote-workflows/.github/workflows/ci.yaml@v1
+    with:
+      handle: sqr-065
+      apt_packages: 'graphviz'
+      upload: ${{ github.event_name == 'push' }}
+    secrets:
+      ltd_username: ${{ secrets.LTD_USERNAME }}
+      ltd_password: ${{ secrets.LTD_PASSWORD }}
+```
+
+### Inputs
+
+- `handle` (string, required). The lower-cased document handle, used as the subdomain for publishing to the `lsst.io` site.
+- `apt_packages` (string, optional). The packages to install via `apt-get install` into the Ubuntu CI environment. For example, to install both `graphviz` and `imagemagick` use `apt_packages: 'graphviz imagemagick'`.
+- `build_command` (string, optional). The shell command run to build the document. By default, the command is `make html` so that you can add pre- and post-build steps through the `Makefile`. However, you can explicitly change the build script through this input if required.
+- `upload` (boolean, optional). A boolean flag to enable uploading the build to `lsst.io`. For example, to only upload from push events, use `upload: ${{ github.event_name == 'push' }}`. The default is to upload.
+
+### Secrets
+
+- `ltd_username` (required). The account username for the LTD service. Generally this is the org-wide GitHub Actions Secret, `ltd_username: ${{ secrets.LTD_USERNAME }}`. If `inputs.upload` is `false`, this can be left as an empty string.
+- `ltd_password` (required). The account password for the LTD service. Generally this is the org-wide GitHub Actions Secret, `ltd_username: ${{ secrets.LTD_PASSWORD }}`. If `inputs.upload` is `false`, this can be left as an empty string.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # rubin-sphinx-technote-workflows
-Reusable GitHub Actions Workflow for building Sphinx-based Rubin technotes
+
+**Reusable GitHub Actions Workflow for building Sphinx-based Rubin technotes.**


### PR DESCRIPTION
Individual technote projects can call this repo's workflow with a simplified set of inputs, making it easier to maintain workflows at scale. It uses GitHub's new-ish [reusable workflows feature](https://docs.github.com/en/actions/using-workflows/reusing-workflows).

```yaml
name: CI

on: ["pull_request", "push"]

jobs:
  call-workflow:
    uses: lsst-sqre/rubin-sphinx-technote-workflows/ci.yaml@tickets/DM-34274
    with:
      handle: sqr-065
      upload: ${{ github.event_name == 'push' }}
    secrets:
      ltd_username: ${{ secrets.LTD_USERNAME }}
      ltd_password: ${{ secrets.LTD_PASSWORD }}
```

This workflow is being implemented in the technote template at https://github.com/lsst/templates/pull/156

An example of what it looks like for this workflow to be called is https://github.com/lsst-sqre/sqr-065/actions/runs/2091901107

I'm planning to version this repo similar to how GitHub Actions are versioned. i.e. created releases with semantic tags such as `v1.0.0`. There's a github workflow that should automatically create/update the corresponding major version tag, i.e. `v1`.