### PR TITLE
DM-40815: Update to Python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Python install
         run: |


### PR DESCRIPTION
Use Python 3.11, which will be required for documenteer 1.0.0