### PR TITLE
DM-41337: Conditionall install tox and run pre-commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,16 +53,21 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install ltd-conveyor
 
       - name: Build
         run: |
           ${{ inputs.build_command }}
 
+      - name: Convert handle to lowercase
+        id: lowercase
+        run: |
+          echo "PROJECT=$(echo ${{ inputs.handle }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Upload
         if: inputs.upload && ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' )
-        env:
-          LTD_PASSWORD: ${{ secrets.ltd_password }}
-          LTD_USERNAME: ${{ secrets.ltd_username }}
-        run: |
-          ltd upload --gh --dir _build/html --product ${{ inputs.handle }}
+        uses: lsst-sqre/ltd-upload@v1
+        with:
+          project: ${{ env.PROJECT }}
+          dir: "_build/html"
+          username: ${{ secrets.ltd_username }}
+          password: ${{ secrets.ltd_password }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
+      
+      - name: Run pre-commit
+        if: ${{ hashFiles('.pre-commit-config.yaml') != '' }}
+        uses: pre-commit/action@v3.0.0
+      
+      - name: Install tox
+        if: ${{ hashFiles('tox.ini') != '' }}
+        run: |
+          python -m pip install tox
 
       - name: Build
         run: |


### PR DESCRIPTION
New technotes may use pre-commit and tox, and we'd like to prepare for those if their configuration files are present.

- if tox.ini exists, then install tox. The Build command itself will then likely run a tox environment (potentially via a make target)
- if .pre-commit-config.yaml exists, then run the pre-commit action.

This approach avoids us from putting tox and pre-commit in a technote's requirements.txt file, which would pollute the tox environments unnecessarily.

As well, use the lsst-sqre/ltd-upload action to perform the LTD upload to delegate that work.